### PR TITLE
use stx_common.bytesToHex 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "@stacks/common": "^6.0.0",
+    "@stacks/network": "^6.0.0",
+    "@stacks/transactions": "^6.0.0",
+    "@stacks/wallet-sdk": "^6.0.0"
+  }
+}

--- a/wallet-cli
+++ b/wallet-cli
@@ -854,7 +854,7 @@ async function tokenTransferCLI(argv) {
   };
 
   const transaction = await stx.makeSTXTokenTransfer(txOpts);
-  const transactionHex = transaction.serialize().toString('hex');
+  const transactionHex = stx_common.bytesToHex(transaction.serialize());
   return transactionHex;
 }
 
@@ -893,7 +893,7 @@ async function contractPublishCLI(argv) {
   };
   
   const transaction = await stx.makeContractDeploy(txOpts);
-  const transactionHex = transaction.serialize().toString('hex');
+  const transactionHex = stx_common.bytesTohex(transaction.serialize());
   return transactionHex;
 }
 
@@ -949,7 +949,7 @@ async function contractCallCLI(argv) {
   };
   
   const transaction = await stx.makeContractCall(txOpts);
-  const transactionHex = transaction.serialize().toString('hex');
+  const transactionHex = stx_common.bytesToHex(transaction.serialize());
   return transactionHex;
 }
 


### PR DESCRIPTION
Replaces calls from .toString'hex') to stx_common.bytesToHex(). stx.serialize replaced Buffer with Uint8Array for efficiency.

https://github.com/hirosystems/stacks.js/commit/5445b73e05ec0c09414395331bfd37788545f1e1